### PR TITLE
Add documentation for Stone Binaries and removed overlapping instruction from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Navigate to the example test directory:
 cd /tmp/stone-packaging/test_files/
 ```
 
-Copy or download the binary files from the latest release to this directory.
-
 Run the prover:
 ```bash
 cpu_air_prover \
@@ -85,11 +83,6 @@ docker pull ghcr.io/dipdup-io/stone-packaging/stone-prover:latest
 
 ### Creating and Verifying a Test Proof Using Docker
 
-Clone the repository:
-
-```bash
-git clone https://github.com/dipdup-io/stone-packaging.git /tmp/stone-packaging
-```
 
 Run the Docker container with a volume mounted:
 
@@ -119,12 +112,6 @@ wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/stone
 ```
 
 ### Creating and Verifying a Test Proof Using the .deb Package
-
-Clone the repository:
-
-```bash
-git clone https://github.com/dipdup-io/stone-packaging.git /tmp/stone-packaging
-```
 
 Navigate to the example test directory:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Follow-up work:
 
 ## Usage Instructions
 
+### Downloading Binaries
+Before cloning the repository, download the binaries based on your operating system:
+
 ### Download Binaries for x86_64
 
 ```bash
@@ -43,11 +46,7 @@ wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_a
 
 ### Creating and Verifying a Test Proof Using Binaries
 
-Clone the repository:
-
-```bash
-git clone https://github.com/dipdup-io/stone-packaging.git /tmp/stone-packaging
-```
+Note: You still need to clone the repo to create and verify a test proof.
 
 Navigate to the example test directory:
 
@@ -82,7 +81,6 @@ docker pull ghcr.io/dipdup-io/stone-packaging/stone-prover:latest
 ```
 
 ### Creating and Verifying a Test Proof Using Docker
-
 
 Run the Docker container with a volume mounted:
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Follow-up work:
 ## Usage Instructions
 
 ### Downloading Binaries
-Before cloning the repository, download the binaries based on your operating system:
+Note: Before cloning the repository, download the binaries based on your operating system:
 
 ### Download Binaries for x86_64
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,18 @@ wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_a
 ### Creating and Verifying a Test Proof Using Binaries
 
 Clone the repository:
-    ```bash
-    git clone https://github.com/dipdup-io/stone-packaging.git /tmp/stone-packaging
-    ```
+
+```bash
+git clone https://github.com/dipdup-io/stone-packaging.git /tmp/stone-packaging
+```
 
 Navigate to the example test directory:
 
 ```bash
 cd /tmp/stone-packaging/test_files/
 ```
+
+Copy or download the binary files from the latest release to this directory.
 
 Run the prover:
 ```bash
@@ -82,6 +85,12 @@ docker pull ghcr.io/dipdup-io/stone-packaging/stone-prover:latest
 
 ### Creating and Verifying a Test Proof Using Docker
 
+Clone the repository:
+
+```bash
+git clone https://github.com/dipdup-io/stone-packaging.git /tmp/stone-packaging
+```
+
 Run the Docker container with a volume mounted:
 
 ```bash
@@ -110,6 +119,12 @@ wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/stone
 ```
 
 ### Creating and Verifying a Test Proof Using the .deb Package
+
+Clone the repository:
+
+```bash
+git clone https://github.com/dipdup-io/stone-packaging.git /tmp/stone-packaging
+```
 
 Navigate to the example test directory:
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ Follow-up work:
 
 ## Usage Instructions
 
-### Downloading Binaries
-Note: Before cloning the repository, download the binaries based on your operating system:
-
 ### Download Binaries for x86_64
 
 ```bash
@@ -46,7 +43,10 @@ wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_a
 
 ### Creating and Verifying a Test Proof Using Binaries
 
-Note: You still need to clone the repo to create and verify a test proof.
+Clone the repository:
+    ```bash
+    git clone https://github.com/dipdup-io/stone-packaging.git /tmp/stone-packaging
+    ```
 
 Navigate to the example test directory:
 

--- a/docs/pages/install/binaries.md
+++ b/docs/pages/install/binaries.md
@@ -1,0 +1,107 @@
+# Stone Packaging - Installation Guide
+
+This guide provides detailed instructions on how to download and install the [Stone](https://github.com/starkware-libs/stone-prover) binaries, based on your operating system (OS) and architecture so follow along.
+
+## Supported Architectures
+
+Stone binaries are available for the following architectures:
+- **x86_64** (Linux and macOS)
+- **ARM64** (macOS and Linux)
+
+## Download and Install Binaries
+
+### For macOS (ARM64)
+
+1. Download the cpu_air_prover and cpu_air_verifier binaries:
+
+    ```bash
+    wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-arm64 -O /usr/local/bin/cpu_air_prover
+    wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-arm64 -O /usr/local/bin/cpu_air_verifier
+    ```
+    
+2. Make the binaries executable:
+
+    ```bash
+    chmod +x /usr/local/bin/cpu_air_prover
+    chmod +x /usr/local/bin/cpu_air_verifier
+    ```
+
+3. Move the binaries to /usr/bin for system-wide access (optional):
+
+    ```bash
+    sudo mv /usr/local/bin/cpu_air_prover /usr/bin/
+    sudo mv /usr/local/bin/cpu_air_verifier /usr/bin/
+    ```
+
+    This step is optional but recommended if you want to make the binaries globally available without adding /usr/local/bin to your PATH.
+
+### For Linux (x86_64)
+
+1. Download the `cpu_air_prover` and `cpu_air_verifier` binaries:
+
+   ```bash
+   sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-x86_64 -O /usr/local/bin/cpu_air_prover
+   sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-x86_64 -O /usr/local/bin/cpu_air_verifier
+   ```
+
+2. Make the binaries executable:
+
+    ```bash
+    sudo chmod +x /usr/local/bin/cpu_air_prover
+    sudo chmod +x /usr/local/bin/cpu_air_verifier
+    ```
+
+3. Move the binaries to /usr/bin for system-wide access (optional):
+
+    ```bash
+    sudo mv /usr/local/bin/cpu_air_prover /usr/bin/
+    sudo mv /usr/local/bin/cpu_air_verifier /usr/bin/
+    ```
+
+    This step is actually optional but recommended if you want to make the binaries globally available without adding /usr/local/bin to your PATH.
+
+## Adding Stone Binaries to the System PATH
+
+If you prefer to leave the binaries in /usr/local/bin or any other folder, you can add that folder to your system’s PATH variable. This will ensure that the binaries can be executed from any directory.
+
+1. Open your shell configuration file (e.g., .bashrc for bash, .zshrc for zsh):
+
+    ```bash
+    nano ~/.bashrc   # for bash users
+    nano ~/.zshrc    # for zsh users
+    ```
+
+2. Add the following line to include /usr/local/bin in your PATH:
+
+    ```bash
+    export PATH="/usr/local/bin:$PATH"
+    ```
+
+3. Save and close the file, then reload your shell:
+
+    ```bash
+    source ~/.bashrc   
+    # or
+    source ~/.zshrc
+    ```
+
+4.  Apply the changes by running:
+
+    ```bash
+    source ~/.bashrc   # for bash users
+    source ~/.zshrc    # for zsh users
+    ```
+
+This step ensures that binaries placed in /usr/local/bin can be accessed from anywhere in your system without needing to move them to /usr/bin.
+
+### Verifying Installation
+
+After placing the binaries or updating the PATH, you can verify the installation by running:
+
+    ```bash
+    cpu_air_prover --help
+    cpu_air_verifier --help
+    ```
+
+If you see usage information, then the installation is successful. Hope you're smilling.
+

--- a/docs/pages/install/binaries.md
+++ b/docs/pages/install/binaries.md
@@ -14,51 +14,50 @@ Stone binaries are available for the following architectures:
 
 1. Download the cpu_air_prover and cpu_air_verifier binaries:
 
-    ```bash
-    wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-arm64 -O /usr/local/bin/cpu_air_prover
-    wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-arm64 -O /usr/local/bin/cpu_air_verifier
-    ```
-    
+```bash
+wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-arm64 -O /usr/local/bin/cpu_air_prover
+wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-arm64 -O /usr/local/bin/cpu_air_verifier
+```
 2. Make the binaries executable:
 
-    ```bash
-    chmod +x /usr/local/bin/cpu_air_prover
-    chmod +x /usr/local/bin/cpu_air_verifier
-    ```
+```bash
+chmod +x /usr/local/bin/cpu_air_prover
+chmod +x /usr/local/bin/cpu_air_verifier
+```
 
 3. Move the binaries to /usr/bin for system-wide access (optional):
 
-    ```bash
-    sudo mv /usr/local/bin/cpu_air_prover /usr/bin/
-    sudo mv /usr/local/bin/cpu_air_verifier /usr/bin/
-    ```
+```bash
+sudo mv /usr/local/bin/cpu_air_prover /usr/bin/
+sudo mv /usr/local/bin/cpu_air_verifier /usr/bin/
+```
 
-    This step is optional but recommended if you want to make the binaries globally available without adding /usr/local/bin to your PATH.
+This step is optional but recommended if you want to make the binaries globally available without adding /usr/local/bin to your PATH.
 
 ### For Linux (x86_64)
 
 1. Download the `cpu_air_prover` and `cpu_air_verifier` binaries:
 
-   ```bash
-   sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-x86_64 -O /usr/local/bin/cpu_air_prover
-   sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-x86_64 -O /usr/local/bin/cpu_air_verifier
-   ```
+```bash
+sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-x86_64 -O /usr/local/bin/cpu_air_prover
+sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-x86_64 -O /usr/local/bin/cpu_air_verifier
+```
 
 2. Make the binaries executable:
 
-    ```bash
-    sudo chmod +x /usr/local/bin/cpu_air_prover
-    sudo chmod +x /usr/local/bin/cpu_air_verifier
-    ```
+```bash
+sudo chmod +x /usr/local/bin/cpu_air_prover
+sudo chmod +x /usr/local/bin/cpu_air_verifier
+```
 
 3. Move the binaries to /usr/bin for system-wide access (optional):
 
-    ```bash
-    sudo mv /usr/local/bin/cpu_air_prover /usr/bin/
-    sudo mv /usr/local/bin/cpu_air_verifier /usr/bin/
-    ```
+```bash
+sudo mv /usr/local/bin/cpu_air_prover /usr/bin/
+sudo mv /usr/local/bin/cpu_air_verifier /usr/bin/
+```
 
-    This step is actually optional but recommended if you want to make the binaries globally available without adding /usr/local/bin to your PATH.
+This step is actually optional but recommended if you want to make the binaries globally available without adding /usr/local/bin to your PATH.
 
 ## Adding Stone Binaries to the System PATH
 
@@ -66,31 +65,31 @@ If you prefer to leave the binaries in /usr/local/bin or any other folder, you c
 
 1. Open your shell configuration file (e.g., .bashrc for bash, .zshrc for zsh):
 
-    ```bash
-    nano ~/.bashrc   # for bash users
-    nano ~/.zshrc    # for zsh users
-    ```
+```bash
+nano ~/.bashrc # for bash users
+nano ~/.zshrc # for zsh users
+```
 
 2. Add the following line to include /usr/local/bin in your PATH:
 
-    ```bash
-    export PATH="/usr/local/bin:$PATH"
-    ```
+```bash
+export PATH="/usr/local/bin:$PATH"
+```
 
 3. Save and close the file, then reload your shell:
 
-    ```bash
-    source ~/.bashrc   
-    # or
-    source ~/.zshrc
-    ```
+```bash
+source ~/.bashrc 
+# or
+source ~/.zshrc
+```
 
-4.  Apply the changes by running:
+4. Apply the changes by running:
 
-    ```bash
-    source ~/.bashrc   # for bash users
-    source ~/.zshrc    # for zsh users
-    ```
+```bash
+source ~/.bashrc # for bash users
+source ~/.zshrc # for zsh users
+```
 
 This step ensures that binaries placed in /usr/local/bin can be accessed from anywhere in your system without needing to move them to /usr/bin.
 
@@ -98,10 +97,9 @@ This step ensures that binaries placed in /usr/local/bin can be accessed from an
 
 After placing the binaries or updating the PATH, you can verify the installation by running:
 
-    ```bash
-    cpu_air_prover --help
-    cpu_air_verifier --help
-    ```
+```bash
+cpu_air_prover --help
+cpu_air_verifier --help
+```
 
 If you see usage information, then the installation is successful. Hope you're smilling.
-

--- a/docs/pages/install/binaries.md
+++ b/docs/pages/install/binaries.md
@@ -5,8 +5,8 @@ This guide provides detailed instructions on how to download and install the [St
 ## Supported Architectures
 
 Stone binaries are available for the following architectures:
-- **x86_64** (Linux and macOS)
-- **ARM64** (macOS and Linux)
+- **x86_64 Linux**
+- **ARM64 macOS**
 
 ## Download and Install Binaries
 

--- a/docs/pages/install/binaries.md
+++ b/docs/pages/install/binaries.md
@@ -76,19 +76,12 @@ nano ~/.zshrc # for zsh users
 export PATH="/usr/local/bin:$PATH"
 ```
 
-3. Save and close the file, then reload your shell:
+3. Save and close the file, then reload your shell to apply the changes:
 
 ```bash
 source ~/.bashrc 
 # or
 source ~/.zshrc
-```
-
-4. Apply the changes by running:
-
-```bash
-source ~/.bashrc # for bash users
-source ~/.zshrc # for zsh users
 ```
 
 This step ensures that binaries placed in /usr/local/bin can be accessed from anywhere in your system without needing to move them to /usr/bin.


### PR DESCRIPTION
This pull request includes the following updates:

    Added Documentation for Stone Binaries:
    - Created a new documentation page in the path docs/pages/install/binaries.md.
    - This page provides detailed instructions on how to download and install Stone binaries based on different OS/architecture.
    -  Added instructions on how to place binaries in system paths and configure system PATH variables.

    Removed Overlapping Instructions from README:
    - Cleaned up redundant sections in the README.md to avoid duplication with the new documentation.
    
This contribution makes the instructions clearer by moving the binary installation steps to a separate document and making the README.md clean and easier to read. Thanks