### PR TITLE
GitHub Action for DockerHub build and publish #19

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,83 @@
+name: Build and Publish image to Docker Hub
+on:
+    repository_dispatch:
+      types: [prover-update]
+    push:
+      tags:
+        - 'v*.*.*'
+
+jobs:
+  build_and_push:
+    env:
+      DOCKER_HUB: ${{ secrets.DOCKER_LOGIN }}
+      DOCKER_TAGS: latest
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        target:
+          - name: stone-prover
+            dockerfile: Dockerfile
+          - name: cpu_air_prover
+            dockerfile: air_prover/Dockerfile
+          - name: cpu_air_verifier
+            dockerfile: air_verifier/Dockerfile
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Determine Docker Tags
+        id: set-tag
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "repository_dispatch" ]]; then
+            echo "Latest version tags..."
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG_NAME=$(echo ${GITHUB_REF} | sed 's/refs\/tags\///')
+            echo "DOCKER_TAGS=${TAG_NAME}" >> $GITHUB_ENV
+          else
+            echo "No valid ref for tagging. Exiting..."
+            exit 1
+          fi
+        shell: bash
+
+      - name: Set image tags & labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_HUB }}/${{ matrix.target.name }}
+          tags: ${{ env.DOCKER_TAGS }}
+
+      - name: Build And Push Image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.target.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        if: github.event.repository.fork == false
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ secrets.DOCKER_LOGIN }}/${{ matrix.target.name }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+

--- a/README.md
+++ b/README.md
@@ -149,36 +149,7 @@ Run the verifier to confirm the proof:
 cpu_air_verifier --in_file=fibonacci_proof.json && echo "Successfully verified example proof."
 ```
 
-## Docker Image Publishing
-
-This repository contains a GitHub Actions workflow that automatically builds and publishes Docker images to Docker Hub.
-
-- **Workflow file:** `.github/workflows/docker-publish.yml`
-
-### Usage
-
-- The workflow is triggered by any push of a tag (v*.*.*) or when a prover-update event is dispatched. It builds the Docker image and publishes it to Docker Hub.
-
-### Workflow Overview
-
-The workflow performs the following actions:
-- Checks out the repository code.
-- Sets up Docker Buildx for cross-platform builds.
-- Logs in to Docker Hub using the credentials stored in GitHub Secrets.
-- Determine Docker Push Tags
-- Builds the Docker image based on the repository content.
-- Pushes the image to Docker Hub with the specified tag.
-- Generates an attestation for the image artifact (not applicable to forked repositories).
-- Logs out of Docker Hub after the process is complete.
-
-### Tests
-
-1. Forked the original repository.
-2. Update the workflow file by setting `env.DOCKER_HUB` to your testing docker hub account.
-3. Temporarily updated the workflow trigger branch for testing purposes.
-4. Pushed a test tag to trigger the workflow.
-5. Monitored the workflow in the **Actions** tab.
-6. Verified the Docker image was pushed to local Docker Hub.
+This project is supported by Nethermind and Starknet Foundation via [OnlyDust platform](https://app.onlydust.com/p/stone-packaging-)
 
 
 ### USNG VOCS TO GENERATE DOCUMENTATION LOCALHOST SITE
@@ -236,5 +207,3 @@ To add a new page to the documentation:
 
 1. Create a new markdown file in the `docs/pages/` directory.
 2. Add the new page to the sidebar in `vocs.config.ts`.
-
-This project is supported by Nethermind and Starknet Foundation via [OnlyDust platform](https://app.onlydust.com/p/stone-packaging-)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,36 @@ Run the verifier to confirm the proof:
 cpu_air_verifier --in_file=fibonacci_proof.json && echo "Successfully verified example proof."
 ```
 
-This project is supported by Nethermind and Starknet Foundation via [OnlyDust platform](https://app.onlydust.com/p/stone-packaging-)
+## Docker Image Publishing
+
+This repository contains a GitHub Actions workflow that automatically builds and publishes Docker images to Docker Hub.
+
+- **Workflow file:** `.github/workflows/docker-publish.yml`
+
+### Usage
+
+- The workflow is triggered by any push of a tag (v*.*.*) or when a prover-update event is dispatched. It builds the Docker image and publishes it to Docker Hub.
+
+### Workflow Overview
+
+The workflow performs the following actions:
+- Checks out the repository code.
+- Sets up Docker Buildx for cross-platform builds.
+- Logs in to Docker Hub using the credentials stored in GitHub Secrets.
+- Determine Docker Push Tags
+- Builds the Docker image based on the repository content.
+- Pushes the image to Docker Hub with the specified tag.
+- Generates an attestation for the image artifact (not applicable to forked repositories).
+- Logs out of Docker Hub after the process is complete.
+
+### Tests
+
+1. Forked the original repository.
+2. Update the workflow file by setting `env.DOCKER_HUB` to your testing docker hub account.
+3. Temporarily updated the workflow trigger branch for testing purposes.
+4. Pushed a test tag to trigger the workflow.
+5. Monitored the workflow in the **Actions** tab.
+6. Verified the Docker image was pushed to local Docker Hub.
 
 
 ### USNG VOCS TO GENERATE DOCUMENTATION LOCALHOST SITE
@@ -207,3 +236,5 @@ To add a new page to the documentation:
 
 1. Create a new markdown file in the `docs/pages/` directory.
 2. Add the new page to the sidebar in `vocs.config.ts`.
+
+This project is supported by Nethermind and Starknet Foundation via [OnlyDust platform](https://app.onlydust.com/p/stone-packaging-)


### PR DESCRIPTION
Hi:

Please review this PR. I have attached the GitHub actions logs for reference and included links to the public Docker Hub repository containing the created images.

Action Logs: https://github.com/jsanchez556/stone-packaging/actions/runs/11147558391
DockerHub: https://hub.docker.com/r/blockchainercr/stone-packaging/tags
 