### PR TITLE
feat: update github action to use dispatch

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   repository_dispatch:
     types: [prover-update]
-  pull_request:
-    branches:
-      - "master"
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   build:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,13 +1,11 @@
 name: Build
+
 on:
-  push:
-    branches:
-      - 'master'
-    tags:
-      - 'v*.*.*'
+  repository_dispatch:
+    types: [prover-update]
   pull_request:
     branches:
-      - 'master'
+      - "master"
 
 jobs:
   build:
@@ -20,7 +18,7 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
### Summary

This PR addresses [Issue #6](https://github.com/dipdup-io/stone-packaging/issues/6) by adding a webhook trigger to the Stone Prover GitHub Action workflow.

### Changes

- Added a `repository_dispatch` trigger to the GitHub Action workflow for `stone-prover` ([related pull request](https://github.com/baking-bad/stone-prover/pull/4)).
- Updated the `ghcr.yaml` action to be triggered on `repository_dispatch`.

### Test Results

- View the successful test on the Stone Prover repo [here](https://github.com/JoE11-y/stone-prover/actions/runs/11138069024/job/30952492155).
- View the successful test of the action in this repo [here](https://github.com/JoE11-y/stone-packaging/actions/runs/11137912508/job/30952094396).