### PR TITLE
[Book] Add verification guide for Stone proofs on Starknet

### DIFF
--- a/docs/pages/advanced/starknet.md
+++ b/docs/pages/advanced/starknet.md
@@ -1,0 +1,109 @@
+## Verifying Stone proofs on Starknet
+
+This guide provides detailed instructions on creating and verifying Stone proofs on Starknet as well as how to deploy integrity contracts. Follow the steps below to ensure a smooth verification process.
+
+## Prerequisites
+
+Before you begin, ensure you have the following tools and dependencies installed:
+
+- [Scarb](https://docs.swmansion.com/scarb/download.html)
+- [Starknet Foundry](https://github.com/foundry-rs/starknet-foundry?tab=readme-ov-file#installation)
+
+Make sure to follow the usage instructions as outlined [here](https://github.com/dipdup-io/stone-packaging?tab=readme-ov-file#usage-instructions).
+
+## Creating and Verifying a Test Proof
+
+To create and verify a test proof, follow the steps outlined in the [Creating and Verifying a Test Proof Guide](https://github.com/dipdup-io/stone-packaging?tab=readme-ov-file#creating-and-verifying-a-test-proof-using-binaries).
+
+In this example, we will use the `fibonacci_proof.json`.
+
+
+### Splitting the Proof
+
+Run the following command to generate the proof:
+
+```bash
+cpu_air_prover  --out_file=fibonacci_proof.json \
+    --private_input_file=fibonacci_private_input.json \
+    --public_input_file=fibonacci_public_input.json \
+    --prover_config_file=cpu_air_prover_config.json \
+    --parameter_file=cpu_air_params.json \
+    --generate_annotations true
+```
+
+Alternatively, you can use the `stark_evm_adapter` by following the instructions [here](https://github.com/zksecurity/stark-evm-adapter?tab=readme-ov-file#cli).
+
+## Example Using `stark_evm_adapter`
+
+Run the following command to generate an annotated proof:
+
+```bash
+stark_evm_adapter gen-annotated-proof \
+    --stone-proof-file fibonacci_proof.json \
+    --stone-annotation-file fibonacci_proof_annotation.txt \
+    --stone-extra-annotation-file fibonacci_proof_annotation_extra.txt \
+    --output fibonacci_annotated_proof.json
+```
+
+Proceed when receiving the next output:
+```bash
+Annotated proof wrote to fibonacci_annotated_proof.json
+```
+## Utilizing the Herodotus Integrity File to Serialize the Proof
+
+Clone the Herodotus Integrity repository for later procedures:
+
+```bash
+git clone https://github.com/HerodotusDev/integrity.git
+```
+
+Alternatively, you can install the proof serializer tool directly:
+
+```bash
+cargo install --git https://github.com/HerodotusDev/integrity proof_serializer
+```
+
+## Serializing the Proof
+To serialize the proof, use the proof_serializer tool as follows:
+
+- For the Original Proof:
+
+```bash
+proof_serializer < fibonacci_proof.json > fibonacci_calldata
+```
+- For the Annotated Proof:
+
+```bash
+proof_serializer < fibonacci_annotated_proof.json > fibonacci_calldata
+```
+
+Ensure you follow the [prerequisites](https://github.com/HerodotusDev/integrity?tab=readme-ov-file#prerequisites) outlined in the Herodotus Integrity repository before proceeding.
+
+## Setting Up Starknet Foundry
+
+To interact with Starknet Foundry, set up your account and configuration as follows.
+
+### Acount Management
+
+Refer to the following links for managing your Starknet Foundry account:
+
+[Account Management](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account/account.html)
+[Add account](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account/add.html)
+[Create account](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account/create.html)
+
+Make sure you set up up your 'snfoundry.toml' configuration.
+
+### Deploying Your Account
+
+Before deploying make sure you prefunded your account.
+
+[Deploy Account](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account/deploy.html)
+
+Execute the next [example](https://github.com/HerodotusDev/integrity?tab=readme-ov-file#monolith-proof) to check if the setup correct.
+
+## Deploying Integrity Contracts
+-TODO
+
+
+
+

--- a/docs/pages/advanced/starknet.md
+++ b/docs/pages/advanced/starknet.md
@@ -14,7 +14,7 @@ Make sure to follow the next usage instructions as referenced [here](https://git
 
 ### Download Binaries
 
-By following the next [installation guide](https://github.com/dipdup-io/stone-packaging/blob/master/docs/pages/install/binaries.md#download-and-install-binaries).
+By following the next [installation guide](../install/binaries.md).
 
 ### Creating and Verifying a Test Proof Using Binaries
 

--- a/docs/pages/advanced/starknet.md
+++ b/docs/pages/advanced/starknet.md
@@ -12,21 +12,9 @@ Before you begin, ensure you have the following tools and dependencies installed
 
 Make sure to follow the next usage instructions as referenced [here](https://github.com/dipdup-io/stone-packaging?tab=readme-ov-file#usage-instructions).
 
-### Download Binaries for x86_64
+### Download Binaries
 
-```bash
-sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-x86_64 -O /usr/local/bin/cpu_air_prover && sudo chmod +x /usr/local/bin/cpu_air_prover
-
-sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-x86_64 -O /usr/local/bin/cpu_air_verifier && sudo chmod +x /usr/local/bin/cpu_air_verifier
-```
-
-### Download Binaries for macOS ARM64
-
-```bash
-wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-arm64 -O /usr/local/bin/cpu_air_prover && chmod +x /usr/local/bin/cpu_air_prover
-
-wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-arm64 -O /usr/local/bin/cpu_air_verifier && chmod +x /usr/local/bin/cpu_air_verifier
-```
+By following the next [installation guide](https://github.com/dipdup-io/stone-packaging/blob/master/docs/pages/install/binaries.md#download-and-install-binaries).
 
 ### Creating and Verifying a Test Proof Using Binaries
 
@@ -46,24 +34,6 @@ cd /tmp/stone-packaging/test_files/
 
 Copy or download the binary files from the latest release to this directory.
 
-Run the prover:
-```bash
-cpu_air_prover \
-    --out_file=fibonacci_proof.json \
-    --private_input_file=fibonacci_private_input.json \
-    --public_input_file=fibonacci_public_input.json \
-    --prover_config_file=cpu_air_prover_config.json \
-    --parameter_file=cpu_air_params.json
-```
-
-The proof will be available at `fibonacci_proof.json`.
-
-Run the verifier to verify the proof:
-
-```bash
-cpu_air_verifier --in_file=fibonacci_proof.json && echo "Successfully verified example proof."
-```
-
 ### Splitting the Proof
 
 Run the following command to generate the annotated split proof:
@@ -75,6 +45,14 @@ cpu_air_prover  --out_file=fibonacci_proof.json \
     --prover_config_file=cpu_air_prover_config.json \
     --parameter_file=cpu_air_params_integrity.json \
     --generate_annotations true
+```
+
+The proof will be available at `fibonacci_proof.json`.
+
+Run the verifier to verify the proof:
+
+```bash
+cpu_air_verifier --in_file=fibonacci_proof.json && echo "Successfully verified example proof."
 ```
 
 ## stark_evm_adapter

--- a/docs/pages/advanced/starknet.md
+++ b/docs/pages/advanced/starknet.md
@@ -4,23 +4,69 @@ This guide provides detailed instructions on creating and verifying Stone proofs
 
 ## Prerequisites
 
-Before you begin, ensure you have the following tools and dependencies installed:
+Before you begin, ensure you have the following tools and dependencies installed these are outlined here [Integrity prerequisites](https://github.com/HerodotusDev/integrity?tab=readme-ov-file#prerequisites).
 
+- [Rust](https://www.rust-lang.org/tools/install)
 - [Scarb](https://docs.swmansion.com/scarb/download.html)
 - [Starknet Foundry](https://github.com/foundry-rs/starknet-foundry?tab=readme-ov-file#installation)
 
-Make sure to follow the usage instructions as outlined [here](https://github.com/dipdup-io/stone-packaging?tab=readme-ov-file#usage-instructions).
+Make sure to follow the next usage instructions as referenced [here](https://github.com/dipdup-io/stone-packaging?tab=readme-ov-file#usage-instructions).
 
-## Creating and Verifying a Test Proof
+### Download Binaries for x86_64
 
-To create and verify a test proof, follow the steps outlined in the [Creating and Verifying a Test Proof Guide](https://github.com/dipdup-io/stone-packaging?tab=readme-ov-file#creating-and-verifying-a-test-proof-using-binaries).
+```bash
+sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-x86_64 -O /usr/local/bin/cpu_air_prover && sudo chmod +x /usr/local/bin/cpu_air_prover
 
-In this example, we will use the `fibonacci_proof.json`.
+sudo wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-x86_64 -O /usr/local/bin/cpu_air_verifier && sudo chmod +x /usr/local/bin/cpu_air_verifier
+```
 
+### Download Binaries for macOS ARM64
+
+```bash
+wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_prover-arm64 -O /usr/local/bin/cpu_air_prover && chmod +x /usr/local/bin/cpu_air_prover
+
+wget https://github.com/dipdup-io/stone-packaging/releases/latest/download/cpu_air_verifier-arm64 -O /usr/local/bin/cpu_air_verifier && chmod +x /usr/local/bin/cpu_air_verifier
+```
+
+### Creating and Verifying a Test Proof Using Binaries
+
+To create and verify a test proof, follow the next steps outlined in the [Creating and Verifying a Test Proof Guide](https://github.com/dipdup-io/stone-packaging?tab=readme-ov-file#creating-and-verifying-a-test-proof-using-binaries).
+
+Clone the repository:
+
+```bash
+git clone https://github.com/dipdup-io/stone-packaging.git /tmp/stone-packaging
+```
+
+Navigate to the example test directory:
+
+```bash
+cd /tmp/stone-packaging/test_files/
+```
+
+Copy or download the binary files from the latest release to this directory.
+
+Run the prover:
+```bash
+cpu_air_prover \
+    --out_file=fibonacci_proof.json \
+    --private_input_file=fibonacci_private_input.json \
+    --public_input_file=fibonacci_public_input.json \
+    --prover_config_file=cpu_air_prover_config.json \
+    --parameter_file=cpu_air_params.json
+```
+
+The proof will be available at `fibonacci_proof.json`.
+
+Run the verifier to verify the proof:
+
+```bash
+cpu_air_verifier --in_file=fibonacci_proof.json && echo "Successfully verified example proof."
+```
 
 ### Splitting the Proof
 
-Run the following command to generate the proof:
+Run the following command to generate the annotated split proof:
 
 ```bash
 cpu_air_prover  --out_file=fibonacci_proof.json \
@@ -31,11 +77,32 @@ cpu_air_prover  --out_file=fibonacci_proof.json \
     --generate_annotations true
 ```
 
-Alternatively, you can use the `stark_evm_adapter` by following the instructions [here](https://github.com/zksecurity/stark-evm-adapter?tab=readme-ov-file#cli).
+## stark_evm_adapter
 
-## Example Using `stark_evm_adapter`
+Alternatively, you can use the `stark_evm_adapter` by following the next instructions shown [here](https://github.com/zksecurity/stark-evm-adapter?tab=readme-ov-file#cli).
 
-Run the following command to generate an annotated proof:
+### Installation
+
+```bash
+cargo install stark_evm_adapter
+```
+
+### Usage
+
+```bash
+stark_evm_adapter --help
+```
+
+### Example Using `stark_evm_adapter`
+
+To generate an annotated proof:
+
+```bash
+cpu_air_verifier \
+    --in_file test_files/fibonacci_proof.json \
+    --annotation-file test_files/fibonacci_proof_annotation.txt \
+    --extra-output-file test_files/fibonacci_proof_annotation_extra.txt
+```
 
 ```bash
 stark_evm_adapter gen-annotated-proof \
@@ -44,6 +111,10 @@ stark_evm_adapter gen-annotated-proof \
     --stone-extra-annotation-file fibonacci_proof_annotation_extra.txt \
     --output fibonacci_annotated_proof.json
 ```
+
+* `stark_evm_adapter --stone-proof-file` comes from `cpu_air_prover --out_file` (JSON format)
+* `stark_evm_adapter --stone-annotation-file` comes from `cpu_air_verifier --annotation-file` (.txt format)
+* `stark_evm_adapter --stone-extra-annotation-file` comes from `cpu_air_verifier --extra-output-file` (.txt format)
 
 Proceed when receiving the next output:
 ```bash
@@ -63,7 +134,8 @@ Alternatively, you can install the proof serializer tool directly:
 cargo install --git https://github.com/HerodotusDev/integrity proof_serializer
 ```
 
-## Serializing the Proof
+### Serializing the Proof
+
 To serialize the proof, use the proof_serializer tool as follows:
 
 - For the Original Proof:
@@ -77,8 +149,6 @@ proof_serializer < fibonacci_proof.json > fibonacci_calldata
 proof_serializer < fibonacci_annotated_proof.json > fibonacci_calldata
 ```
 
-Ensure you follow the [prerequisites](https://github.com/HerodotusDev/integrity?tab=readme-ov-file#prerequisites) outlined in the Herodotus Integrity repository before proceeding.
-
 ## Setting Up Starknet Foundry
 
 To interact with Starknet Foundry, set up your account and configuration as follows.
@@ -91,7 +161,7 @@ Refer to the following links for managing your Starknet Foundry account:
 [Add account](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account/add.html)
 [Create account](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account/create.html)
 
-Make sure you set up up your 'snfoundry.toml' configuration.
+Make sure you set up up your 'snfoundry.toml' configuration with appropriate account name and RPC url inside your Integrity cloned repository.
 
 ### Deploying Your Account
 

--- a/docs/pages/advanced/starknet.md
+++ b/docs/pages/advanced/starknet.md
@@ -73,7 +73,7 @@ cpu_air_prover  --out_file=fibonacci_proof.json \
     --private_input_file=fibonacci_private_input.json \
     --public_input_file=fibonacci_public_input.json \
     --prover_config_file=cpu_air_prover_config.json \
-    --parameter_file=cpu_air_params.json \
+    --parameter_file=cpu_air_params_integrity.json \
     --generate_annotations true
 ```
 
@@ -169,10 +169,54 @@ Before deploying make sure you prefunded your account.
 
 [Deploy Account](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account/deploy.html)
 
-Execute the next [example](https://github.com/HerodotusDev/integrity?tab=readme-ov-file#monolith-proof) to check if the setup correct.
+Execute the next [example](https://github.com/HerodotusDev/integrity?tab=readme-ov-file#monolith-proof) to check if the setup is correct.
 
-## Deploying Integrity Contracts
--TODO
+## Cairo-VM-Verifier
+
+For veryfing the proof.json you can utilize the next tool by pasting the proof.json file in the drop box, it's made in Rust and WASM in JS: [cairo-vm-verifier](https://demo.swiftness.iosis.tech/)
+
+
+## Deploying in the Integrity Contracts for Verification
+
+Make sure you're in the Integrity cloned repository.
+
+```bash
+cd integrity
+```
+
+For verifying onchain with the Integrity contracts we will use the `verify-on-starknet.sh` script following the [deployed contracts](https://github.com/HerodotusDev/integrity/blob/main/deployed_contracts.md#main-contracts).
+
+This is the main Herodotus example for testing.
+
+```bash
+./verify-on-starknet.sh 0x16409cfef9b6c3e6002133b61c59d09484594b37b8e4daef7dcba5495a0ef1a examples/calldata recursive keccak_248_lsb stone5 cairo0
+```
+
+You can use the next configurations.
+
+- layout: [`dex`, `recursive`, `recursive_with_poseidon`, `small`, `starknet`, `starknet_with_keccak`]
+- hashers: [`keccak`, `blake2s`]
+- cairo_version: [`cairo0`, `cairo1`]
+- stone_version: [`stone5`, `stone6`]
+
+Hash function and hasher bit length are combined into one setting:
+
+- hasher: [`keccak_160_lsb`, `blake2s_160`, `blake2s_248_lsb`]
+
+Following this let's deploy our fibonacci_calldata in the Herodotus [proxy contract](https://github.com/HerodotusDev/integrity?tab=readme-ov-file#factregistry-and-proxy-contract).
+
+```bash
+./verify-on-starknet.sh \
+    0x16409cfef9b6c3e6002133b61c59d09484594b37b8e4daef7dcba5495a0ef1a \
+    /home/'user'/stone-packaging/test_files/fibonacci_calldata \
+    small \
+    keccak_160_lsb \
+    stone6 \
+    cairo1
+```
+
+Wait for the tx and you've made the verification in Starknet! :)
+
 
 
 

--- a/test_files/cpu_air_params_integrity.json
+++ b/test_files/cpu_air_params_integrity.json
@@ -1,0 +1,27 @@
+{
+    "field": "PrimeField0",
+    "channel_hash": "poseidon3",
+    "commitment_hash": "keccak256_masked160_lsb",
+    "n_verifier_friendly_commitment_layers": 1000,
+    "pow_hash": "keccak256",
+    "statement": {
+        "page_hash": "pedersen"
+    },
+    "stark": {
+        "fri": {
+            "fri_step_list": [
+                0,
+                4,
+                3
+            ],
+            "last_layer_degree_bound": 64,
+            "n_queries": 18,
+            "proof_of_work_bits": 24
+        },
+        "log_n_cosets": 4
+    },
+
+    "use_extension_field": false,
+    "verifier_friendly_channel_updates": true,
+    "verifier_friendly_commitment_hash": "poseidon3"
+}


### PR DESCRIPTION
Issue #35

Introduces the first version of the "Verifying Stone Proofs on Starknet" guide. The guide is designed to help developers create and verify Stone proofs within the Starknet ecosystem by providing step-by-step instructions, relevant commands, and necessary configurations.