### PR TITLE
Native packages for Homebrew #17

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -1,0 +1,152 @@
+name: Release Homebrew Package
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runs-on: macos-12
+          - arch: arm64
+            runs-on: macos-14
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          brew install gmp bazelisk
+          pip3 install cpplint pytest numpy sympy==1.12.1 cairo-lang==0.12.0
+
+      - name: Build binaries
+        run: |
+          chmod +x ./build.sh
+          ./build.sh
+
+      - name: Test binaries
+        run: |
+          chmod +x ./test.sh
+          ./test.sh
+
+      - name: Copy and rename binaries for Homebrew
+        run: |
+          cp /tmp/stone-prover/build/bazelbin/src/starkware/main/cpu/cpu_air_prover ./cpu_air_prover-${{ matrix.arch }}
+          cp /tmp/stone-prover/build/bazelbin/src/starkware/main/cpu/cpu_air_verifier ./cpu_air_verifier-${{ matrix.arch }}
+          chmod +x cpu_air_prover-${{ matrix.arch }} cpu_air_verifier-${{ matrix.arch }}
+
+      - name: Package binaries
+        run: tar -czvf stone-prover-macos-${{ matrix.arch }}.tar.gz cpu_air_prover-${{ matrix.arch }} cpu_air_verifier-${{ matrix.arch }}
+
+      - name: Compute SHA256
+        id: compute_sha
+        run: |
+          SHA256=$(shasum -a 256 stone-prover-macos-${{ matrix.arch }}.tar.gz | awk '{ print $1 }')
+          echo "${SHA256}" > sha256_${{ matrix.arch }}.txt
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: stone-prover-macos-${{ matrix.arch }}
+          path: |
+            stone-prover-macos-${{ matrix.arch }}.tar.gz
+
+      - name: Upload sha256
+        uses: actions/upload-artifact@v3
+        with:
+          name: sha256_${{ matrix.arch }}
+          path: |
+            sha256_${{ matrix.arch }}.txt
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download binaries and SHA256 artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: stone-prover-macos-x86_64
+          path: ./release_assets/x86_64
+
+      - name: Download binaries and SHA256 artifacts for arm64
+        uses: actions/download-artifact@v3
+        with:
+          name: stone-prover-macos-arm64
+          path: ./release_assets/arm64
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ./release_assets/x86_64/stone-prover-macos-x86_64.tar.gz
+            ./release_assets/arm64/stone-prover-macos-arm64.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update_formula:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Homebrew Formula Repository
+        uses: actions/checkout@v3
+        with:
+          repository: MrRoudyk/homebrew-stone-prover
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          path: homebrew-stone-prover
+
+      - name: Set up Git
+        working-directory: homebrew-stone-prover
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Download x86_64 SHA256 Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: sha256_x86_64
+          path: ./release_assets/x86_64
+
+      - name: Download arm64 SHA256 Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: sha256_arm64
+          path: ./release_assets/arm64
+
+      - name: Read SHA256
+        run: |
+          SHA256_x86_64=$(cat ./release_assets/x86_64/sha256_x86_64.txt)
+          SHA256_arm64=$(cat ./release_assets/arm64/sha256_arm64.txt)
+          echo "SHA256_x86_64=${SHA256_x86_64}" >> $GITHUB_ENV
+          echo "SHA256_arm64=${SHA256_arm64}" >> $GITHUB_ENV
+
+      - name: Update Homebrew Formula
+        working-directory: homebrew-stone-prover
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          ROOT_URL="https://github.com/MrRoudyk/stone-packaging/releases/download/v${VERSION}"
+
+          sed -i "/^  if Hardware::CPU.arm?$/,/^  end$/c\\
+            if Hardware::CPU.arm?\\
+              url \"${ROOT_URL}/stone-prover-macos-arm64.tar.gz\"\\
+              sha256 \"${SHA256_arm64}\"\\
+            else\\
+              url \"${ROOT_URL}/stone-prover-macos-x86_64.tar.gz\"\\
+              sha256 \"${SHA256_x86_64}\"\\
+            end" Formula/stone-prover.rb
+
+          sed -i "s|version \".*\"|version \"${VERSION}\"|" Formula/stone-prover.rb
+
+          git add Formula/stone-prover.rb
+          git commit -m "Update Stone Prover to version ${VERSION} for arm64 and x86_64" || echo "No changes to commit"
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ The goal of this project is to reduce friction and speed up the process of gener
 - [x] Minimal Docker images for x86_64
 - [x] Native packages for Debian/Ubuntu
 - [x] Native packages for Fedora
+- [x] Homebrew packages
 
 Follow-up work:
 
 - Native packages for Alpine
-- Homebrew packages
 - Technical documentation for file formats (inputs, outputs, memory, trace, proof), and test data
 - Documentation hosted on GitHub Pages
 - Integrated proof decomposition (related to https://github.com/zksecurity/stark-evm-adapter)
@@ -127,6 +127,17 @@ install the .rpm package from the latest release:
 sudo dnf install https://github.com/dipdup-io/stone-packaging/releases/latest/download/stone-prover-fedora-x86_64.rpm
 ```
 
+## Download Homebrew Packages for macOS
+
+Install the `stone-prover` package via Homebrew:
+
+```bash
+brew tap dipdup-io/stone-packaging
+brew install stone-prover
+```
+
+> **Note:** The Homebrew formula is maintained in the [homebrew-stone-prover](https://github.com/dipdup-io/homebrew-stone-prover) repository. If you encounter any issues or wish to contribute to the formula, please visit the repository.
+
 ### Creating and Verifying a Test Proof Using the Native Packages
 
 Clone the repository:
@@ -157,9 +168,6 @@ Run the verifier to confirm the proof:
 ```bash
 cpu_air_verifier --in_file=fibonacci_proof.json && echo "Successfully verified example proof."
 ```
-
-This project is supported by Nethermind and Starknet Foundation via [OnlyDust platform](https://app.onlydust.com/p/stone-packaging-)
-
 
 ### USNG VOCS TO GENERATE DOCUMENTATION LOCALHOST SITE
 
@@ -216,3 +224,6 @@ To add a new page to the documentation:
 
 1. Create a new markdown file in the `docs/pages/` directory.
 2. Add the new page to the sidebar in `vocs.config.ts`.
+
+This project is supported by Nethermind and Starknet Foundation via [OnlyDust platform](https://app.onlydust.com/p/stone-packaging-)
+```


### PR DESCRIPTION
## Pull Request: Native Packages for Homebrew

### Related Issue
Closes [#17](https://github.com/dipdup-io/stone-packaging/issues/17)

### Overview
This pull request migrates the workflow from the forked repository (`MrRoudyk/stone-packaging`) to the main `dipdup-io/stone-packaging` repository.

### Changes Included
- **Homebrew Formula**
  - The Homebrew formula is currently located in [`homebrew-stone-prover`](https://github.com/MrRoudyk/homebrew-stone-prover).

- **Architecture Support**
  - Added build configurations to support the `arm64` architecture.

### Pending Tasks
- **Finalize x86_64 Build**
  - Complete and verify the build process for the `x86_64` architecture.

- **Update Repository Links**
  - Replace all references and links pointing to `MrRoudyk/stone-packaging` with `dipdup-io/stone-packaging` following the repository migration.
  - Update links from the forked repository [`MrRoudyk/homebrew-stone-prover`](https://github.com/MrRoudyk/homebrew-stone-prover) to [`dipdup-io/homebrew-stone-prover`](https://github.com/dipdup-io/homebrew-stone-prover).