### PR TITLE
doc: Publish docs to GitHub Pages

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -1,0 +1,30 @@
+name: Build and Deploy Documentation
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: yarn install
+      - name: Build docs
+        run: yarn build
+        # Github Pages
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/dist
+          force_orphan: true

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -1,8 +1,8 @@
 name: Build and Deploy Documentation
 on:
-  push:
-    branches:
-      - master
+#  push:
+#    branches:
+#      - master
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
Closes issue https://github.com/dipdup-io/stone-packaging/issues/47

To configure the GitHub Pages settings to deploy from the correct branch and folder:
Steps to Configure GitHub Pages:
Go to the Settings tab of your repository.

Scroll down to the Pages section (under Code and automation in the sidebar).

In the Source section:

Branch: Select the gh-pages branch (or the branch you are deploying to).
Folder: Select / (root) if the static files (index.html) are in the root of the branch. If the files are in a specific folder, like
docs/dist/, select that folder.
For example:

Branch: gh-pages
Folder: / (root) or docs/dist depending on where your index.html is.

Click Save.
Once you’ve set up everything:
Go back to the Settings tab of your repository.
In the Pages section, after a successful deployment, a link to your GitHub Pages site should appear (something like https://dipdup-io.github.io/stone-packaging/).
GitHub Pages deployment may take a few minutes. If the site does not appear immediately after deployment, wait for a few minutes and refresh the Settings page.